### PR TITLE
Implement chat list screen with bottom navigation

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -42,6 +42,7 @@ kotlin {
             implementation(compose.runtime)
             implementation(compose.foundation)
             implementation(compose.material3)
+            implementation(compose.materialIconsExtended)
             implementation(compose.ui)
             implementation(compose.components.resources)
             implementation(compose.components.uiToolingPreview)

--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/App.kt
@@ -1,44 +1,14 @@
 package org.kekus.rsachat
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.safeContentPadding
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import org.jetbrains.compose.resources.painterResource
+import androidx.compose.runtime.Composable
 import org.jetbrains.compose.ui.tooling.preview.Preview
-
-import rsachat.composeapp.generated.resources.Res
-import rsachat.composeapp.generated.resources.compose_multiplatform
+import org.kekus.rsachat.chats.ChatListScreen
 
 @Composable
 @Preview
 fun App() {
     MaterialTheme {
-        var showContent by remember { mutableStateOf(false) }
-        Column(
-            modifier = Modifier
-                .safeContentPadding()
-                .fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Button(onClick = { showContent = !showContent }) {
-                Text("Click me!")
-            }
-            AnimatedVisibility(showContent) {
-                val greeting = remember { Greeting().greet() }
-                Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
-                    Image(painterResource(Res.drawable.compose_multiplatform), null)
-                    Text("Compose: $greeting")
-                }
-            }
-        }
+        ChatListScreen()
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/Chat.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/Chat.kt
@@ -1,0 +1,8 @@
+package org.kekus.rsachat.chats
+
+/** Model representing a chat in the list. */
+data class Chat(
+    val id: Long,
+    val title: String,
+    val lastMessage: String
+)

--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatListScreen.kt
@@ -1,0 +1,68 @@
+package org.kekus.rsachat.chats
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+
+/**
+ * Main screen displaying list of chats with bottom navigation and menu.
+ */
+@Composable
+fun ChatListScreen(
+    viewModel: ChatListViewModel = remember { ChatListViewModel() }
+) {
+    val chats by viewModel.chats.collectAsState()
+
+    var menuExpanded by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            SmallTopAppBar(
+                title = { Text("Chats") },
+                actions = {
+                    Box {
+                        IconButton(onClick = { menuExpanded = true }) {
+                            Icon(
+                                imageVector = Icons.Default.MoreVert,
+                                contentDescription = "Menu"
+                            )
+                        }
+                        DropdownMenu(
+                            expanded = menuExpanded,
+                            onDismissRequest = { menuExpanded = false }
+                        ) {
+                            DropdownMenuItem(text = { Text("Settings") }, onClick = { menuExpanded = false })
+                        }
+                    }
+                }
+            )
+        },
+        bottomBar = {
+            NavigationBar {
+                NavigationBarItem(
+                    selected = true,
+                    onClick = {},
+                    label = { Text("Chats") },
+                    icon = { }
+                )
+            }
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+            items(chats) { chat ->
+                ListItem(
+                    headlineText = { Text(chat.title) },
+                    supportingText = { Text(chat.lastMessage) }
+                )
+                Divider()
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatListViewModel.kt
@@ -1,0 +1,18 @@
+package org.kekus.rsachat.chats
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/** ViewModel for the chat list screen. */
+class ChatListViewModel : ViewModel() {
+    private val _chats = MutableStateFlow(sampleChats())
+    val chats: StateFlow<List<Chat>> = _chats.asStateFlow()
+
+    private fun sampleChats(): List<Chat> = listOf(
+        Chat(1, "Alice", "Hey, how's it going?"),
+        Chat(2, "Bob", "Let's meet tomorrow."),
+        Chat(3, "Charlie", "See you soon!")
+    )
+}


### PR DESCRIPTION
## Summary
- create Chat list screen using MVVM
- add Chat model and ViewModel with sample data
- switch App entry to new screen
- include material icons

## Testing
- `./gradlew tasks --all` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685bb4e7fea8832aa8bfd8b78919d79c