### PR TITLE
Add basic chat screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/App.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.remember
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.kekus.rsachat.chats.ChatListScreen
+import org.kekus.rsachat.chats.ChatScreen
 import org.kekus.rsachat.auth.PasswordScreen
 import org.kekus.rsachat.settings.ChangePasswordScreen
 import org.kekus.rsachat.settings.SettingsScreen
@@ -22,7 +23,17 @@ fun App() {
     MaterialTheme {
         when (screen) {
             Screen.Password -> PasswordScreen(onSubmit = component::tryUnlock)
-            Screen.ChatList -> ChatListScreen(onOpenSettings = component::openSettings)
+            Screen.ChatList -> ChatListScreen(
+                onOpenSettings = component::openSettings,
+                onOpenChat = component::openChat
+            )
+            is Screen.Chat -> ChatScreen(
+                chat = screen.chat,
+                onBack = component::back,
+                onForward = {},
+                onReply = {},
+                onDelete = {}
+            )
             Screen.Settings -> {
                 SettingsScreen(
                     onBack = component::back,

--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/App.kt
@@ -28,7 +28,7 @@ fun App() {
                 onOpenChat = component::openChat
             )
             is Screen.Chat -> ChatScreen(
-                chat = screen.chat,
+                chatUI = screen.chatUI,
                 onBack = component::back,
                 onForward = {},
                 onReply = {},

--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/RootComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/RootComponent.kt
@@ -60,6 +60,10 @@ class RootComponent(
         navigation.bringToFront(Screen.Settings)
     }
 
+    fun openChat(chat: chats.Chat) {
+        navigation.bringToFront(Screen.Chat(chat))
+    }
+
     fun openChangePassword() {
         navigation.bringToFront(Screen.ChangePassword)
     }

--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/RootComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/RootComponent.kt
@@ -1,13 +1,11 @@
 package org.kekus.rsachat
 
 import com.arkivanov.decompose.ComponentContext
-import com.arkivanov.decompose.DelicateDecomposeApi
 import com.arkivanov.decompose.router.stack.ChildStack
 import com.arkivanov.decompose.router.stack.StackNavigation
 import com.arkivanov.decompose.router.stack.bringToFront
 import com.arkivanov.decompose.router.stack.childStack
 import com.arkivanov.decompose.router.stack.pop
-import com.arkivanov.decompose.router.stack.push
 import com.arkivanov.decompose.router.stack.replaceCurrent
 import com.arkivanov.decompose.value.Value
 import kotlinx.coroutines.CoroutineScope
@@ -15,6 +13,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.kekus.rsachat.auth.PasswordRepository
+import org.kekus.rsachat.chats.ChatUI
 
 /** Root component managing navigation using Decompose. */
 class RootComponent(
@@ -60,8 +59,8 @@ class RootComponent(
         navigation.bringToFront(Screen.Settings)
     }
 
-    fun openChat(chat: chats.Chat) {
-        navigation.bringToFront(Screen.Chat(chat))
+    fun openChat(chatUI: ChatUI) {
+        navigation.bringToFront(Screen.Chat(chatUI))
     }
 
     fun openChangePassword() {

--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/Screen.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/Screen.kt
@@ -7,6 +7,8 @@ sealed class Screen {
 
     object ChatList : Screen()
 
+    data class Chat(val chat: chats.Chat) : Screen()
+
     object Settings : Screen()
 
     object ChangePassword : Screen()

--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/Screen.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/Screen.kt
@@ -1,5 +1,7 @@
 package org.kekus.rsachat
 
+import org.kekus.rsachat.chats.ChatUI
+
 /** Screens available in the application. */
 
 sealed class Screen {
@@ -7,7 +9,7 @@ sealed class Screen {
 
     object ChatList : Screen()
 
-    data class Chat(val chat: chats.Chat) : Screen()
+    data class Chat(val chatUI: ChatUI) : Screen()
 
     object Settings : Screen()
 

--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/Chat.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/Chat.kt
@@ -6,3 +6,12 @@ data class Chat(
     val title: String,
     val lastMessage: String
 )
+
+/** Simple chat message model. */
+data class ChatMessage(
+    val id: Long,
+    val authorId: Long,
+    val authorName: String,
+    val text: String,
+    val isMine: Boolean
+)

--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatListScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChatBubble
 import androidx.compose.material.icons.filled.MoreVert
@@ -19,6 +20,7 @@ import androidx.compose.ui.Modifier
 @Composable
 fun ChatListScreen(
     onOpenSettings: () -> Unit,
+    onOpenChat: (Chat) -> Unit,
     viewModel: ChatListViewModel = remember { ChatListViewModel() }
 ) {
     val chats by viewModel.chats.collectAsState()
@@ -68,7 +70,8 @@ fun ChatListScreen(
             items(chats) { chat ->
                 ListItem(
                     headlineContent = { Text(chat.title) },
-                    supportingContent = { Text(chat.lastMessage) }
+                    supportingContent = { Text(chat.lastMessage) },
+                    modifier = Modifier.clickable { onOpenChat(chat) }
                 )
                 HorizontalDivider(Modifier, DividerDefaults.Thickness, DividerDefaults.color)
             }

--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatListScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.Modifier
 @Composable
 fun ChatListScreen(
     onOpenSettings: () -> Unit,
-    onOpenChat: (Chat) -> Unit,
+    onOpenChat: (ChatUI) -> Unit,
     viewModel: ChatListViewModel = remember { ChatListViewModel() }
 ) {
     val chats by viewModel.chats.collectAsState()

--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatListViewModel.kt
@@ -10,11 +10,11 @@ class ChatListViewModel : ViewModel() {
 
     // TODO: replace to states with chats list or empty banner
     private val _chats = MutableStateFlow(sampleChats())
-    val chats: StateFlow<List<Chat>> = _chats.asStateFlow()
+    val chats: StateFlow<List<ChatUI>> = _chats.asStateFlow()
 
-    private fun sampleChats(): List<Chat> = listOf(
-        Chat(1, "Alice", "Hey, how's it going?"),
-        Chat(2, "Bob", "Let's meet tomorrow."),
-        Chat(3, "Charlie", "See you soon!")
+    private fun sampleChats(): List<ChatUI> = listOf(
+        ChatUI(1, "Alice", "Hey, how's it going?"),
+        ChatUI(2, "Bob", "Let's meet tomorrow."),
+        ChatUI(3, "Charlie", "See you soon!")
     )
 }

--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatScreen.kt
@@ -53,7 +53,7 @@ fun ChatScreen(
                 reverseLayout = true,
                 verticalArrangement = Arrangement.Bottom
             ) {
-                items(messages, key = { it.id }) { message ->
+                items(messages.reversed(), key = { it.id }) { message ->
                     MessageBubble(
                         message = message,
                         onLongPress = { menuForMessage = message }

--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatScreen.kt
@@ -1,0 +1,145 @@
+package org.kekus.rsachat.chats
+
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.AttachFile
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatScreen(
+    chat: Chat,
+    onBack: () -> Unit,
+    onForward: (ChatMessage) -> Unit,
+    onReply: (ChatMessage) -> Unit,
+    onDelete: (ChatMessage) -> Unit,
+    viewModel: ChatViewModel = remember { ChatViewModel(chat) }
+) {
+    val messages by viewModel.messages.collectAsState()
+    var input by remember { mutableStateOf("") }
+    var showAttach by remember { mutableStateOf(false) }
+    var menuForMessage by remember { mutableStateOf<ChatMessage?>(null) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                title = { Text(chat.title) }
+            )
+        }
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            LazyColumn(
+                modifier = Modifier.weight(1f).fillMaxWidth(),
+                reverseLayout = true,
+                verticalArrangement = Arrangement.Bottom
+            ) {
+                items(messages, key = { it.id }) { message ->
+                    MessageBubble(
+                        message = message,
+                        onLongPress = { menuForMessage = message }
+                    )
+                }
+            }
+            Divider()
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = { showAttach = true }) {
+                    Icon(Icons.Default.AttachFile, contentDescription = "Attach")
+                }
+                OutlinedTextField(
+                    modifier = Modifier.weight(1f),
+                    value = input,
+                    onValueChange = { input = it },
+                    maxLines = 4,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+                    keyboardActions = KeyboardActions(onSend = {
+                        if (input.isNotBlank()) {
+                            viewModel.sendMessage(input)
+                            input = ""
+                        }
+                    })
+                )
+                IconButton(onClick = {
+                    if (input.isNotBlank()) {
+                        viewModel.sendMessage(input)
+                        input = ""
+                    }
+                }) {
+                    Icon(Icons.Default.Send, contentDescription = "Send")
+                }
+            }
+        }
+    }
+
+    DropdownMenu(
+        expanded = showAttach,
+        onDismissRequest = { showAttach = false }
+    ) {
+        DropdownMenuItem(text = { Text("Photo") }, onClick = { showAttach = false })
+        DropdownMenuItem(text = { Text("File") }, onClick = { showAttach = false })
+        DropdownMenuItem(text = { Text("Other") }, onClick = { showAttach = false })
+    }
+
+    menuForMessage?.let { msg ->
+        DropdownMenu(
+            expanded = true,
+            onDismissRequest = { menuForMessage = null }
+        ) {
+            DropdownMenuItem(text = { Text("Reply") }, onClick = { onReply(msg); menuForMessage = null })
+            DropdownMenuItem(text = { Text("Forward") }, onClick = { onForward(msg); menuForMessage = null })
+            if (msg.isMine) {
+                DropdownMenuItem(text = { Text("Delete") }, onClick = { onDelete(msg); menuForMessage = null })
+            }
+        }
+    }
+}
+
+@Composable
+private fun MessageBubble(message: ChatMessage, onLongPress: () -> Unit) {
+    Column(
+        horizontalAlignment = if (message.isMine) Alignment.End else Alignment.Start,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+            .pointerInput(Unit) {
+                detectTapGestures(onLongPress = { onLongPress() })
+            }
+    ) {
+        if (!message.isMine) {
+            Text(message.authorName, fontSize = 12.sp, color = Color.Gray)
+        }
+        Surface(
+            color = if (message.isMine) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant,
+            tonalElevation = 2.dp,
+            shape = MaterialTheme.shapes.medium
+        ) {
+            Text(
+                text = message.text,
+                modifier = Modifier.padding(8.dp),
+                color = if (message.isMine) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatScreen.kt
@@ -23,17 +23,17 @@ import androidx.compose.ui.unit.sp
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ChatScreen(
-    chat: Chat,
+    chatUI: ChatUI,
     onBack: () -> Unit,
-    onForward: (ChatMessage) -> Unit,
-    onReply: (ChatMessage) -> Unit,
-    onDelete: (ChatMessage) -> Unit,
-    viewModel: ChatViewModel = remember { ChatViewModel(chat) }
+    onForward: (ChatMessageUI) -> Unit,
+    onReply: (ChatMessageUI) -> Unit,
+    onDelete: (ChatMessageUI) -> Unit,
+    viewModel: ChatViewModel = remember { ChatViewModel(chatUI) }
 ) {
     val messages by viewModel.messages.collectAsState()
     var input by remember { mutableStateOf("") }
     var showAttach by remember { mutableStateOf(false) }
-    var menuForMessage by remember { mutableStateOf<ChatMessage?>(null) }
+    var menuForMessage by remember { mutableStateOf<ChatMessageUI?>(null) }
 
     Scaffold(
         topBar = {
@@ -43,7 +43,7 @@ fun ChatScreen(
                         Icon(Icons.Default.ArrowBack, contentDescription = "Back")
                     }
                 },
-                title = { Text(chat.title) }
+                title = { Text(chatUI.title) }
             )
         }
     ) { padding ->
@@ -60,7 +60,7 @@ fun ChatScreen(
                     )
                 }
             }
-            Divider()
+            HorizontalDivider(Modifier, DividerDefaults.Thickness, DividerDefaults.color)
             Row(
                 modifier = Modifier.fillMaxWidth().padding(8.dp),
                 verticalAlignment = Alignment.CenterVertically
@@ -117,7 +117,7 @@ fun ChatScreen(
 }
 
 @Composable
-private fun MessageBubble(message: ChatMessage, onLongPress: () -> Unit) {
+private fun MessageBubble(message: ChatMessageUI, onLongPress: () -> Unit) {
     Column(
         horizontalAlignment = if (message.isMine) Alignment.End else Alignment.Start,
         modifier = Modifier

--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatUI.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatUI.kt
@@ -1,14 +1,14 @@
 package org.kekus.rsachat.chats
 
 /** Model representing a chat in the list. */
-data class Chat(
+data class ChatUI(
     val id: Long,
     val title: String,
     val lastMessage: String
 )
 
 /** Simple chat message model. */
-data class ChatMessage(
+data class ChatMessageUI(
     val id: Long,
     val authorId: Long,
     val authorName: String,

--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatViewModel.kt
@@ -1,0 +1,28 @@
+package org.kekus.rsachat.chats
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/** ViewModel managing messages within a chat. */
+class ChatViewModel(private val chat: Chat) : ViewModel() {
+
+    private val _messages = MutableStateFlow(sampleMessages())
+    val messages: StateFlow<List<ChatMessage>> = _messages.asStateFlow()
+
+    fun sendMessage(text: String) {
+        val list = _messages.value.toMutableList()
+        val id = (list.maxOfOrNull { it.id } ?: 0L) + 1
+        list += ChatMessage(id, 0, "Me", text, isMine = true)
+        _messages.value = list
+    }
+
+    fun deleteMessage(id: Long) {
+        _messages.value = _messages.value.filterNot { it.id == id }
+    }
+
+    private fun sampleMessages(): List<ChatMessage> = listOf(
+        ChatMessage(1, 1, chat.title, chat.lastMessage, isMine = false)
+    )
+}

--- a/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/kekus/rsachat/chats/ChatViewModel.kt
@@ -6,15 +6,15 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 /** ViewModel managing messages within a chat. */
-class ChatViewModel(private val chat: Chat) : ViewModel() {
+class ChatViewModel(private val chatUI: ChatUI) : ViewModel() {
 
     private val _messages = MutableStateFlow(sampleMessages())
-    val messages: StateFlow<List<ChatMessage>> = _messages.asStateFlow()
+    val messages: StateFlow<List<ChatMessageUI>> = _messages.asStateFlow()
 
     fun sendMessage(text: String) {
         val list = _messages.value.toMutableList()
         val id = (list.maxOfOrNull { it.id } ?: 0L) + 1
-        list += ChatMessage(id, 0, "Me", text, isMine = true)
+        list += ChatMessageUI(id, 0, "Me", text, isMine = true)
         _messages.value = list
     }
 
@@ -22,7 +22,7 @@ class ChatViewModel(private val chat: Chat) : ViewModel() {
         _messages.value = _messages.value.filterNot { it.id == id }
     }
 
-    private fun sampleMessages(): List<ChatMessage> = listOf(
-        ChatMessage(1, 1, chat.title, chat.lastMessage, isMine = false)
+    private fun sampleMessages(): List<ChatMessageUI> = listOf(
+        ChatMessageUI(1, 1, chatUI.title, chatUI.lastMessage, isMine = false)
     )
 }


### PR DESCRIPTION
## Summary
- add Chat screen and view model
- allow opening chats from chat list
- wire new screen into RootComponent and App
- add simple message model

## Testing
- `./gradlew :composeApp:test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685d0b8485e8832aa33e34086ff11c78